### PR TITLE
Save Orb config inside the Orb directory

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -27,6 +27,7 @@ design and use one or more Omnigres extension.`,
 		var orbName string
 		if len(args) > 0 {
 			orbName = args[0]
+			path = filepath.Join(path, orbName)
 		} else {
 			orbName = filepath.Base(path)
 		}
@@ -40,7 +41,7 @@ design and use one or more Omnigres extension.`,
 			log.Fatal(err)
 		}
 		for _, dir := range []string{"src", "migrations"} {
-			err = fileutils.CreateIfNotExists(filepath.Join(path, orbName, dir), true)
+			err = fileutils.CreateIfNotExists(filepath.Join(path, dir), true)
 			if err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
This fixes the issue when `omnigres.yaml` is saved on the path where the CLI is called from.

It also preserves the behaviour of creating everything in the current CLI path when no `name` is passed to the `init` command.
