### PR TITLE
Stop the container after a ctrl+c in run mode

### DIFF
--- a/orb/docker.go
+++ b/orb/docker.go
@@ -331,6 +331,7 @@ checkContainer:
 		select {
 		case <-sigCtx.Done():
 			fmt.Println("Terminating cluster")
+			d.Stop(ctx)
 		case err = <-errCh:
 			if err != nil {
 				return


### PR DESCRIPTION
The container is currently left running after a ctrl+c when in run mode. I was not sure about the desired behavior so I haven't created any issue, but it seems more intuitive to kill the container.