### PR TITLE
Make binaries available in release page 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+      - uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,2 @@
+builds:
+  - main: ./cmd/omnigres/


### PR DESCRIPTION
Users trying the CLI for the first time would need a development environment to install it from sources.

Solution: Make binaries available in the Github relase page.
This PR uses goreleaser to automate away the build and upload
for several different operating systems and architectures.

I have merged and tested in my fork as seen below
![image](https://github.com/user-attachments/assets/c06541a0-516a-4fb4-9a6d-84962fac521b)
