### PR TITLE
Fail when cluster commands are called without a proper workspace set

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -32,13 +32,19 @@ var migrateCmd = &cobra.Command{
 		ctx := context.Background()
 		orbs := lo.Map(cluster.Config().Orbs, func(cfg orb.OrbCfg, _ int) string { return cfg.Name })
 		err = migrate(ctx, cluster, dbReset, orbs, orbs)
-
+		if err != nil {
+			log.Fatal(err)
+		}
 	},
 }
 
 func migrate(ctx context.Context, cluster orb.OrbCluster, dbReset bool, orbs []string, databases []string) (err error) {
 	if len(orbs) != len(databases) {
 		err = errors.New("orbs and databases have to be of the same size")
+		return
+	}
+	if len(orbs) == 0 {
+		err = errors.New("You need at least one configured Orb to migrate")
 		return
 	}
 	logger := log.New(os.Stdout)

--- a/orb/config.go
+++ b/orb/config.go
@@ -2,9 +2,9 @@ package orb
 
 import (
 	"errors"
+	"fmt"
 	"github.com/omnigres/cli/internal/fileutils"
 	"github.com/spf13/viper"
-	"os"
 	"path/filepath"
 )
 
@@ -62,12 +62,7 @@ func LoadConfig(path string) (cfg *Config, err error) {
 	v.SetConfigFile(filepath.Join(path, "omnigres.yaml"))
 	err = v.ReadInConfig()
 	if err != nil {
-		if _, ok := err.(*os.PathError); ok {
-			cfg = NewConfig()
-			err = nil
-			return
-		}
-		return
+		return nil, fmt.Errorf("omnigres.yaml not found in %s. Try setting a different workspace with -w or running omnigres init to create a new project config.", path)
 	}
 
 	cfg = NewConfig()


### PR DESCRIPTION
When a cluster command such as migrate or start is called without a proper configuration the current CLI proceeds with an empty config that yields behavior hard to understand for a newcomer.

## Proposed solution

We can be more strict requiring an existing config to run such commands. 
This also allows for better error messages guiding the user during the initial project creation.
