### PR TITLE
Problem: Inspecting any runtime value in the CLI requires either a debugger or code change.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,12 @@ var rootCmd = &cobra.Command{
 	Use:   "omnigres",
 	Short: "Omnigres CLI",
 	Long:  `Omnigres CLI toolkit allows easy creation and management of Omnigres applications and orbs.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if verbose {
+			log.SetLevel(log.DebugLevel)
+			log.Debug("Verbose mode enabled")
+		}
+	},
 }
 
 func Execute() {
@@ -22,6 +28,7 @@ func Execute() {
 }
 
 var workspace string
+var verbose bool
 
 func init() {
 	cwd, err := os.Getwd()
@@ -29,4 +36,5 @@ func init() {
 		log.Fatal(err)
 	}
 	rootCmd.PersistentFlags().StringVarP(&workspace, "workspace", "w", cwd, "path to workspace")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "display debug messages")
 }

--- a/orb/config.go
+++ b/orb/config.go
@@ -2,6 +2,7 @@ package orb
 
 import (
 	"errors"
+	"github.com/charmbracelet/log"
 	"github.com/omnigres/cli/internal/fileutils"
 	"github.com/spf13/viper"
 	"os"
@@ -59,10 +60,13 @@ func (c *Config) SaveAs(path string) (err error) {
 
 func LoadConfig(path string) (cfg *Config, err error) {
 	v := viper.New()
-	v.SetConfigFile(filepath.Join(path, "omnigres.yaml"))
+	configPath := filepath.Join(path, "omnigres.yaml")
+	log.Debug("Loading config", "path", configPath)
+	v.SetConfigFile(configPath)
 	err = v.ReadInConfig()
 	if err != nil {
 		if _, ok := err.(*os.PathError); ok {
+			log.Debug("Creating blank config")
 			cfg = NewConfig()
 			err = nil
 			return


### PR DESCRIPTION
Solution: Having a debug log level accessible through a verbose flag
will be useful not only for development but also for users trying to
understand issues during the execution. I started emitting the
configuration file being loaded as a debug message since this was my
motivating use case.
