### PR TITLE
Capture command

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -19,10 +19,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var migrateCmd = &cobra.Command{
-	Use:   "migrate",
-	Short: "Migrate orbs",
-	Long:  `By default, will migrate all listed orbs`,
+var captureCmd = &cobra.Command{
+	Use:   "capture",
+	Short: "Capture orb schema changes",
+	Long:  `By default, will capture all listed orbs`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var cluster orb.OrbCluster
 		var err error
@@ -43,14 +43,8 @@ var migrateCmd = &cobra.Command{
 		}
 
 		ctx := context.Background()
-		log.Debug("Migrating orbs", "orbs", orbs)
-		err = assembleOrbs(
-			ctx,
-			cluster,
-			dbReset,
-			orbs,
-			func(orbName string) string { return orbName },
-		)
+		log.Debug("Capturing orbs", "orbs", orbs)
+		captureOrbs(ctx, cluster, orbs)
 	},
 }
 
@@ -76,6 +70,89 @@ func currentOrbs(cluster orb.OrbCluster, dir string) ([]string, error) {
 	}
 
 	return currentOrbs(cluster, parent)
+}
+
+func captureSchemaRevision(
+	ctx context.Context,
+	cluster orb.OrbCluster,
+	orbName string,
+) (err error) {
+	var db *sql.DB
+	db, err = cluster.Connect(ctx, orbName)
+	if err != nil {
+		return
+	}
+
+	log.Infof("Capturing schema for orb %s", orbName)
+	_, err = db.ExecContext(ctx, "create extension if not exists omni_schema cascade")
+	if err != nil {
+		return err
+	}
+
+	jsonMessageReporting := func(notice *pq.Error) {
+		log.Infof("%s", notice.Message)
+	}
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer conn.Close()
+	conn.Raw(func(driverConn any) error {
+		pq.SetNoticeHandler(driverConn.(driver.Conn), jsonMessageReporting)
+		return nil
+	})
+	var revision string
+	err = db.QueryRowContext(
+		ctx,
+		`select omni_schema.capture_schema_revision(omni_vfs.local_fs($1), 'src', 'revisions')`,
+		fmt.Sprintf("/mnt/host/%s", orbName),
+	).Scan(&revision)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = db.ExecContext(ctx, fmt.Sprintf("drop database \"%s\"", revision))
+	if err != nil {
+		log.Errorf("Could not remove revision. You can try to manually remove using DROP DATABASE %s", revision)
+	}
+	log.Infof("📦 Revision %s created", revision)
+
+	return
+}
+
+func captureOrbs(
+	ctx context.Context,
+	cluster orb.OrbCluster,
+	orbs []string,
+) (err error) {
+	var db *sql.DB
+	db, err = cluster.Connect(ctx, "omnigres")
+	if err != nil {
+		return
+	}
+	for _, orbName := range orbs {
+		log.Infof("Capturing orb %s", orbName)
+		var dbExists bool
+		err := db.QueryRowContext(
+			ctx,
+			`select exists(select from pg_database where datname = $1)`,
+			orbName,
+		).Scan(&dbExists)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if !dbExists {
+			_, err = db.ExecContext(ctx, fmt.Sprintf(`create database %q`, orbName))
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		captureSchemaRevision(ctx, cluster, orbName)
+	}
+	return
 }
 
 func assembleOrbs(
@@ -185,9 +262,6 @@ func assembleSchema(ctx context.Context, db *sql.DB, orbSource string, dbName st
 	}
 }
 
-var dbReset bool
-
 func init() {
-	rootCmd.AddCommand(migrateCmd)
-	migrateCmd.Flags().BoolVarP(&dbReset, "dbReset", "r", false, "dbReset")
+	rootCmd.AddCommand(captureCmd)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -119,7 +119,7 @@ var runCmd = &cobra.Command{
 					},
 				},
 			}
-		err = cluster.Start(ctx, options)
+		err = cluster.Start(ctx, options, nil, nil)
 
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -22,7 +22,7 @@ var startCmd = &cobra.Command{
 		ctx := context.Background()
 
 		readyCh := make(chan orb.OrbCluster, 1)
-		err = cluster.Start(ctx, orb.OrbClusterStartOptions{Runfile: true, Listeners: []orb.OrbStartEventListener{
+		err = cluster.StartWithCurrentUser(ctx, orb.OrbClusterStartOptions{Runfile: true, Listeners: []orb.OrbStartEventListener{
 			{Ready: func(cluster orb.OrbCluster) {
 				readyCh <- cluster
 			}}}})
@@ -36,7 +36,7 @@ var startCmd = &cobra.Command{
 
 		<-readyCh
 
-		fmt.Println("Omnigres Orb cluster started.\n")
+		log.Info("Omnigres Orb cluster started.")
 
 		var endpoints []orb.Endpoint
 		endpoints, err = cluster.Endpoints(ctx)

--- a/orb/cluster.go
+++ b/orb/cluster.go
@@ -35,7 +35,8 @@ type OrbClusterStartOptions struct {
 
 type OrbCluster interface {
 	Configure(options OrbOptions) error
-	Start(ctx context.Context, options OrbClusterStartOptions) error
+	Start(ctx context.Context, options OrbClusterStartOptions, user *string, entryPoint []string) error
+	StartWithCurrentUser(ctx context.Context, options OrbClusterStartOptions) error
 	Stop(ctx context.Context) error
 	Endpoints(ctx context.Context) ([]Endpoint, error)
 	Connect(ctx context.Context, database ...string) (*sql.DB, error)


### PR DESCRIPTION
Problem: Connecting and running `capture_schema_revision` manually is too
much trouble for an everyday task.

Solution: Provide a CLI command capture that automates all the toil
away. It connects to the orb database, calls the capture_schema_revision
function with the proper paths (inferred from working directory) and
remove the revision database once it finishes creating the revision
files.

## Why do we need to change the way we start the database

On Linux the docker container mounts the host directory (used to read sources and write the revision files) with the same permissions and ownership (by uid). This means that inside the container, the database running with the `postgres` user will not necessarily be able to write the revision files  during `capture_schema_revision`.

The solution proposed here is to run the container using the UID of the current user (the one calling omnigres CLI).

[This gist](https://gist.github.com/mrtns/69a92fb387c20bf9add622c4304876b6) has some context on the general issue of user mapping between host and container systems.

In order to do that we need to do some workaround as described on [PostgreSQL docker image documentation](https://github.com/docker-library/docs/blob/master/postgres/README.md#arbitrary---user-notes): Initialize the target directory separately from the final runtime with a chown in between. 

We still have to test this on MacOS and Windows, since the directory bind has a completely different behavior there. The solution here is only tested and seems to be necessary only for Linux based OSs. 

## Command output

![image](https://github.com/user-attachments/assets/cd864a63-eb85-4742-a4c0-8fc284f83101)


