### PR TITLE
Assemble & capture commands

### DIFF
--- a/cmd/assemble.go
+++ b/cmd/assemble.go
@@ -62,6 +62,7 @@ func assembleOrbs(
 	var db *sql.DB
 	db, err = cluster.Connect(ctx, "omnigres")
 	if err != nil {
+    log.Error("Could not connect to orb. Ensure the docker container is running, perhaps 'omnigres start' will fix it.")
 		return
 	}
 	for _, orbName := range orbs {

--- a/cmd/assemble.go
+++ b/cmd/assemble.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/charmbracelet/log"
+	"github.com/lib/pq"
+	"github.com/omnigres/cli/orb"
+	"github.com/spf13/cobra"
+)
+
+var assembleCmd = &cobra.Command{
+	Use:   "assemble",
+	Short: "Assemble or reassemble orb",
+	Long:  `By default, will assemble all listed orbs`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var cluster orb.OrbCluster
+		var err error
+		cluster, err = getOrbCluster()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		log.Debug("Workspace", "workspace", workspace)
+		cwd, err := os.Getwd()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		orbs, err := currentOrbs(cluster, cwd)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		ctx := context.Background()
+		log.Debug("Capturing orbs", "orbs", orbs)
+		assembleOrbs(
+			ctx,
+			cluster,
+			dbReset,
+			orbs,
+			func(orbName string) string { return orbName },
+		)
+	},
+}
+
+func assembleOrbs(
+	ctx context.Context,
+	cluster orb.OrbCluster,
+	dbReset bool,
+	orbs []string,
+	databaseForOrb func(string) string,
+) (err error) {
+	var db *sql.DB
+	db, err = cluster.Connect(ctx, "omnigres")
+	if err != nil {
+		return
+	}
+	for _, orbName := range orbs {
+		log.Infof("Assembling orb %s", orbName)
+		dbName := databaseForOrb(orbName)
+		var dbExists bool
+		err := db.QueryRowContext(
+			ctx,
+			`select exists(select from pg_database where datname = $1)`,
+			dbName,
+		).Scan(&dbExists)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if dbReset && dbExists {
+			if err != sql.ErrNoRows {
+				_, err = db.ExecContext(ctx, fmt.Sprintf(`drop database %q`, dbName))
+				if err != nil {
+					log.Fatal(err)
+				}
+			}
+		}
+
+		if dbReset || !dbExists {
+			_, err = db.ExecContext(ctx, fmt.Sprintf(`create database %q`, dbName))
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		orbSource := path.Join(orbName, "src")
+		assembleSchema(ctx, db, orbSource, dbName)
+	}
+	return
+}
+
+func assembleSchema(ctx context.Context, db *sql.DB, orbSource string, dbName string) {
+	logger := log.New(os.Stdout)
+	logger.SetReportTimestamp(true)
+
+	logger.SetPrefix(fmt.Sprintf("[%s] ", dbName))
+
+	levels := make(map[string]log.Level)
+	levels["info"] = log.InfoLevel
+	levels["error"] = log.ErrorLevel
+	jsonMessageReporting := func(notice *pq.Error) {
+		var message map[string]interface{}
+		err := json.NewDecoder(strings.NewReader(notice.Message)).Decode(&message)
+		if err != nil {
+			logger.Errorf("Message is not valid JSON: %s", notice.Message)
+			return
+		}
+
+		mapToArray := func(m map[string]interface{}) []interface{} {
+			result := make([]interface{}, 0, len(m)*2) // Allocate slice with enough capacity
+			for key, value := range m {
+				result = append(result, key, value)
+			}
+			return result
+		}
+		strippedMessage := maps.Clone(message)
+		delete(strippedMessage, "type")
+		delete(strippedMessage, "message")
+		tags := mapToArray(strippedMessage)
+		logger.Log(levels[message["type"].(string)], message["message"], tags...)
+	}
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+	conn.Raw(func(driverConn any) error {
+		pq.SetNoticeHandler(driverConn.(driver.Conn), jsonMessageReporting)
+		return nil
+	})
+
+	rows, err := conn.QueryContext(ctx,
+		`select migration_filename, migration_statement, execution_error from omni_schema.assemble_schema($1, omni_vfs.local_fs('/mnt/host'), $2) where execution_error is not null`,
+		fmt.Sprintf("dbname=%s user=omnigres", dbName), orbSource)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var migration_filename, migration_statement, execution_error sql.NullString
+		err = rows.Scan(&migration_filename, &migration_statement, &execution_error)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+	}
+}
+
+var dbReset bool
+
+func init() {
+	rootCmd.AddCommand(assembleCmd)
+	assembleCmd.Flags().BoolVarP(&dbReset, "dbReset", "r", false, "dbReset")
+}

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -19,7 +19,7 @@ import (
 
 var captureCmd = &cobra.Command{
 	Use:   "capture",
-	Short: "Capture orb schema changes",
+	Short: "Capture a revision",
 	Long:  `By default, will capture all listed orbs`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var cluster orb.OrbCluster
@@ -153,8 +153,6 @@ func captureOrbs(
 }
 
 func init() {
-	rootCmd.AddCommand(captureCmd)
-
 	handler := cloudeventHandler{
 		Callback: func(e *cloudevents.Event) {
 			switch e.Type() {

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -125,6 +125,7 @@ func captureOrbs(
 	var db *sql.DB
 	db, err = cluster.Connect(ctx, "omnigres")
 	if err != nil {
+    log.Error("Could not connect to orb. Ensure the docker container is running, perhaps 'omnigres start' will fix it.")
 		return
 	}
 	for _, orbName := range orbs {

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -4,13 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
-	"encoding/json"
 	"fmt"
-	"maps"
 	"os"
-	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/charmbracelet/log"
 	"github.com/lib/pq"
@@ -153,113 +149,6 @@ func captureOrbs(
 		captureSchemaRevision(ctx, cluster, orbName)
 	}
 	return
-}
-
-func assembleOrbs(
-	ctx context.Context,
-	cluster orb.OrbCluster,
-	dbReset bool,
-	orbs []string,
-	databaseForOrb func(string) string,
-) (err error) {
-	var db *sql.DB
-	db, err = cluster.Connect(ctx, "omnigres")
-	if err != nil {
-		return
-	}
-	for _, orbName := range orbs {
-		log.Infof("Assembling orb %s", orbName)
-		dbName := databaseForOrb(orbName)
-		var dbExists bool
-		err := db.QueryRowContext(
-			ctx,
-			`select exists(select from pg_database where datname = $1)`,
-			dbName,
-		).Scan(&dbExists)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		if dbReset && dbExists {
-			if err != sql.ErrNoRows {
-				_, err = db.ExecContext(ctx, fmt.Sprintf(`drop database %q`, dbName))
-				if err != nil {
-					log.Fatal(err)
-				}
-			}
-		}
-
-		if dbReset || !dbExists {
-			_, err = db.ExecContext(ctx, fmt.Sprintf(`create database %q`, dbName))
-			if err != nil {
-				log.Fatal(err)
-			}
-		}
-
-		orbSource := path.Join(orbName, "src")
-		assembleSchema(ctx, db, orbSource, dbName)
-	}
-	return
-}
-
-func assembleSchema(ctx context.Context, db *sql.DB, orbSource string, dbName string) {
-	logger := log.New(os.Stdout)
-	logger.SetReportTimestamp(true)
-
-	logger.SetPrefix(fmt.Sprintf("[%s] ", dbName))
-
-	levels := make(map[string]log.Level)
-	levels["info"] = log.InfoLevel
-	levels["error"] = log.ErrorLevel
-	jsonMessageReporting := func(notice *pq.Error) {
-		var message map[string]interface{}
-		err := json.NewDecoder(strings.NewReader(notice.Message)).Decode(&message)
-		if err != nil {
-			logger.Errorf("Message is not valid JSON: %s", notice.Message)
-			return
-		}
-
-		mapToArray := func(m map[string]interface{}) []interface{} {
-			result := make([]interface{}, 0, len(m)*2) // Allocate slice with enough capacity
-			for key, value := range m {
-				result = append(result, key, value)
-			}
-			return result
-		}
-		strippedMessage := maps.Clone(message)
-		delete(strippedMessage, "type")
-		delete(strippedMessage, "message")
-		tags := mapToArray(strippedMessage)
-		logger.Log(levels[message["type"].(string)], message["message"], tags...)
-	}
-
-	conn, err := db.Conn(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer conn.Close()
-	conn.Raw(func(driverConn any) error {
-		pq.SetNoticeHandler(driverConn.(driver.Conn), jsonMessageReporting)
-		return nil
-	})
-
-	rows, err := conn.QueryContext(ctx,
-		`select migration_filename, migration_statement, execution_error from omni_schema.assemble_schema($1, omni_vfs.local_fs('/mnt/host'), $2) where execution_error is not null`,
-		fmt.Sprintf("dbname=%s user=omnigres", dbName), orbSource)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var migration_filename, migration_statement, execution_error sql.NullString
-		err = rows.Scan(&migration_filename, &migration_statement, &execution_error)
-		if err != nil {
-			log.Error(err)
-			return
-		}
-	}
 }
 
 func init() {

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -167,7 +167,7 @@ func init() {
 				}
 
 				style := lipgloss.NewStyle().
-          SetString("⏳ " + message).
+					SetString("⏳ " + message).
 					PaddingLeft(2).
 					Width(120).
 					Foreground(lipgloss.Color("201"))

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -19,10 +19,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var migrateCmd = &cobra.Command{
-	Use:   "migrate",
-	Short: "Migrate orbs",
-	Long:  `By default, will migrate all listed orbs`,
+var captureCmd = &cobra.Command{
+	Use:   "capture",
+	Short: "Capture orb schema changes",
+	Long:  `By default, will capture all listed orbs`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var cluster orb.OrbCluster
 		var err error
@@ -43,14 +43,8 @@ var migrateCmd = &cobra.Command{
 		}
 
 		ctx := context.Background()
-		log.Debug("Migrating orbs", "orbs", orbs)
-		err = assembleOrbs(
-			ctx,
-			cluster,
-			dbReset,
-			orbs,
-			func(orbName string) string { return orbName },
-		)
+		log.Debug("Capturing orbs", "orbs", orbs)
+		captureOrbs(ctx, cluster, orbs)
 	},
 }
 
@@ -76,6 +70,89 @@ func currentOrbs(cluster orb.OrbCluster, dir string) ([]string, error) {
 	}
 
 	return currentOrbs(cluster, parent)
+}
+
+func captureSchemaRevision(
+	ctx context.Context,
+	cluster orb.OrbCluster,
+	orbName string,
+) (err error) {
+	var db *sql.DB
+	db, err = cluster.Connect(ctx, orbName)
+	if err != nil {
+		return
+	}
+
+	log.Infof("Capturing schema for orb %s", orbName)
+	_, err = db.ExecContext(ctx, "create extension if not exists omni_schema cascade")
+	if err != nil {
+		return err
+	}
+
+	jsonMessageReporting := func(notice *pq.Error) {
+		log.Infof("%s", notice.Message)
+	}
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer conn.Close()
+	conn.Raw(func(driverConn any) error {
+		pq.SetNoticeHandler(driverConn.(driver.Conn), jsonMessageReporting)
+		return nil
+	})
+	var revision string
+	err = db.QueryRowContext(
+		ctx,
+		`select omni_schema.capture_schema_revision(omni_vfs.local_fs($1), 'src', 'revisions')`,
+		fmt.Sprintf("/mnt/host/%s", orbName),
+	).Scan(&revision)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = db.ExecContext(ctx, fmt.Sprintf("drop database \"%s\"", revision))
+	if err != nil {
+		log.Errorf("Could not remove revision. You can try to manually remove using DROP DATABASE %s", revision)
+	}
+	log.Infof("📦 Revision %s created", revision)
+
+	return
+}
+
+func captureOrbs(
+	ctx context.Context,
+	cluster orb.OrbCluster,
+	orbs []string,
+) (err error) {
+	var db *sql.DB
+	db, err = cluster.Connect(ctx, "omnigres")
+	if err != nil {
+		return
+	}
+	for _, orbName := range orbs {
+		log.Infof("Capturing orb %s", orbName)
+		var dbExists bool
+		err := db.QueryRowContext(
+			ctx,
+			`select exists(select from pg_database where datname = $1)`,
+			orbName,
+		).Scan(&dbExists)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if !dbExists {
+			_, err = db.ExecContext(ctx, fmt.Sprintf(`create database %q`, orbName))
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		captureSchemaRevision(ctx, cluster, orbName)
+	}
+	return
 }
 
 func assembleOrbs(
@@ -185,9 +262,6 @@ func assembleSchema(ctx context.Context, db *sql.DB, orbSource string, dbName st
 	}
 }
 
-var dbReset bool
-
 func init() {
-	rootCmd.AddCommand(migrateCmd)
-	migrateCmd.Flags().BoolVarP(&dbReset, "dbReset", "r", false, "dbReset")
+	rootCmd.AddCommand(captureCmd)
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/charmbracelet/log"
+	"github.com/omnigres/cli/orb"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var migrateCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: "Migrate revisions",
+	Run: func(cmd *cobra.Command, args []string) {
+		var cluster orb.OrbCluster
+		var err error
+		cluster, err = getOrbCluster()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		log.Debug("Workspace", "workspace", workspace)
+		cwd, err := os.Getwd()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		orbs, err := currentOrbs(cluster, cwd)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		ctx := context.Background()
+		log.Debug("Migrate revisions in orbs", "orbs", orbs)
+		migrateRevisions(
+			ctx,
+			cluster,
+			orbs,
+		)
+	},
+}
+
+func migrateRevisions(
+	ctx context.Context,
+	cluster orb.OrbCluster,
+	orbs []string,
+) (err error) {
+	var db *sql.DB
+	db, err = cluster.Connect(ctx, "omnigres")
+	if err != nil {
+		log.Error("Could not connect to orb. Ensure the docker container is running, perhaps 'omnigres start' will fix it.")
+		return
+	}
+	for _, orbName := range orbs {
+		log.Infof("Migrating orb %s", orbName)
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+		err = setupCloudevents(ctx, conn)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+		defer conn.Close()
+
+		var dbExists bool
+		err = db.QueryRowContext(
+			ctx,
+			`select exists(select from pg_database where datname = $1)`,
+			orbName,
+		).Scan(&dbExists)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if !dbExists {
+			_, err = db.ExecContext(ctx, fmt.Sprintf(`create database %q`, orbName))
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		var rows *sql.Rows
+		rows, err = conn.QueryContext(
+			ctx,
+			`select revision, omni_schema.migrate_to_schema_revision(omni_vfs.local_fs($1), 'revisions', revision, $2) is null as success
+from omni_schema.schema_revisions(omni_vfs.local_fs($1), 'revisions')`,
+			fmt.Sprintf("/mnt/host/%s", orbName),
+			fmt.Sprintf("dbname=%s user=omnigres", orbName),
+		)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+		var revision string
+		var success bool
+		for rows.Next() {
+			err = rows.Scan(&revision, &success)
+			if success {
+				log.Infof("✅ Applied revision %s", revision)
+			} else {
+				log.Infof("🔴 Failed to apply revision %s", revision)
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/revision.go
+++ b/cmd/revision.go
@@ -4,9 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/charmbracelet/lipgloss"
-	cloudevents "github.com/cloudevents/sdk-go/v2"
-
 	"github.com/charmbracelet/log"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/spf13/cobra"
 )
 
@@ -19,6 +18,7 @@ func init() {
 	rootCmd.AddCommand(revisionCmd)
 	revisionCmd.AddCommand(captureCmd)
 	revisionCmd.AddCommand(revisionListCmd)
+	revisionCmd.AddCommand(migrateCmd)
 
 	handler := cloudeventHandler{
 		Callback: func(e *cloudevents.Event) {

--- a/cmd/revision.go
+++ b/cmd/revision.go
@@ -18,6 +18,7 @@ var revisionCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(revisionCmd)
 	revisionCmd.AddCommand(captureCmd)
+	revisionCmd.AddCommand(revisionListCmd)
 
 	handler := cloudeventHandler{
 		Callback: func(e *cloudevents.Event) {

--- a/cmd/revision.go
+++ b/cmd/revision.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/charmbracelet/lipgloss"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"github.com/charmbracelet/log"
+	"github.com/spf13/cobra"
+)
+
+var revisionCmd = &cobra.Command{
+	Use:   "revision",
+	Short: "Revision management",
+}
+
+func init() {
+	rootCmd.AddCommand(revisionCmd)
+	revisionCmd.AddCommand(captureCmd)
+
+	handler := cloudeventHandler{
+		Callback: func(e *cloudevents.Event) {
+			switch e.Type() {
+			case "org.omnigres.omni_schema.progress_report.v1":
+				message := string(e.Data())
+				err := json.Unmarshal(e.Data(), &message)
+				if err != nil {
+					log.Errorf("Error parsing progress report %s", string(e.Data()))
+					return
+				}
+
+				style := lipgloss.NewStyle().
+					SetString("⏳ " + message).
+					PaddingLeft(2).
+					Width(120).
+					Foreground(lipgloss.Color("201"))
+				fmt.Print(style.Render() + "\r")
+			default:
+			}
+		},
+	}
+	cloudeventHandlers = append(cloudeventHandlers, handler)
+}

--- a/cmd/revision_list.go
+++ b/cmd/revision_list.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/charmbracelet/lipgloss"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"github.com/charmbracelet/log"
+	"github.com/spf13/cobra"
+)
+
+var revisionCmd = &cobra.Command{
+	Use:   "revision",
+	Short: "Revision management",
+}
+
+func init() {
+	rootCmd.AddCommand(revisionCmd)
+	revisionCmd.AddCommand(captureCmd)
+
+	handler := cloudeventHandler{
+		Callback: func(e *cloudevents.Event) {
+			switch e.Type() {
+			case "org.omnigres.omni_schema.progress_report.v1":
+				message := string(e.Data())
+				err := json.Unmarshal(e.Data(), &message)
+				if err != nil {
+					log.Errorf("Error parsing progress report %s", string(e.Data()))
+					return
+				}
+
+				style := lipgloss.NewStyle().
+					SetString("⏳ " + message).
+					PaddingLeft(2).
+					Width(120).
+					Foreground(lipgloss.Color("201"))
+				fmt.Print(style.Render() + "\r")
+			default:
+			}
+		},
+	}
+	cloudeventHandlers = append(cloudeventHandlers, handler)
+}

--- a/cmd/revision_list.go
+++ b/cmd/revision_list.go
@@ -1,44 +1,95 @@
 package cmd
 
 import (
-	"encoding/json"
+	"context"
+	"database/sql"
 	"fmt"
-	"github.com/charmbracelet/lipgloss"
-	cloudevents "github.com/cloudevents/sdk-go/v2"
-
 	"github.com/charmbracelet/log"
+	"github.com/omnigres/cli/orb"
 	"github.com/spf13/cobra"
+	"os"
 )
 
-var revisionCmd = &cobra.Command{
-	Use:   "revision",
-	Short: "Revision management",
+var revisionListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List revisions",
+	Run: func(cmd *cobra.Command, args []string) {
+		var cluster orb.OrbCluster
+		var err error
+		cluster, err = getOrbCluster()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		log.Debug("Workspace", "workspace", workspace)
+		cwd, err := os.Getwd()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		orbs, err := currentOrbs(cluster, cwd)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		ctx := context.Background()
+		log.Debug("List revisions in orbs", "orbs", orbs)
+		listRevisions(
+			ctx,
+			cluster,
+			dbReset,
+			orbs,
+			func(orbName string) string { return orbName },
+		)
+	},
 }
 
-func init() {
-	rootCmd.AddCommand(revisionCmd)
-	revisionCmd.AddCommand(captureCmd)
-
-	handler := cloudeventHandler{
-		Callback: func(e *cloudevents.Event) {
-			switch e.Type() {
-			case "org.omnigres.omni_schema.progress_report.v1":
-				message := string(e.Data())
-				err := json.Unmarshal(e.Data(), &message)
-				if err != nil {
-					log.Errorf("Error parsing progress report %s", string(e.Data()))
-					return
-				}
-
-				style := lipgloss.NewStyle().
-					SetString("⏳ " + message).
-					PaddingLeft(2).
-					Width(120).
-					Foreground(lipgloss.Color("201"))
-				fmt.Print(style.Render() + "\r")
-			default:
-			}
-		},
+func listRevisions(
+	ctx context.Context,
+	cluster orb.OrbCluster,
+	dbReset bool,
+	orbs []string,
+	databaseForOrb func(string) string,
+) (err error) {
+	var db *sql.DB
+	db, err = cluster.Connect(ctx, "omnigres")
+	if err != nil {
+		log.Error("Could not connect to orb. Ensure the docker container is running, perhaps 'omnigres start' will fix it.")
+		return
 	}
-	cloudeventHandlers = append(cloudeventHandlers, handler)
+	for _, orbName := range orbs {
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer conn.Close()
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+
+		var rows *sql.Rows
+		rows, err = conn.QueryContext(
+			ctx,
+			`with revs as (select revision, parents, metadata from omni_schema.schema_revisions(omni_vfs.local_fs($1), 'revisions')) 
+                     select revision, not exists (select from revs r1 where r.revision = any(r1.parents)) as top from revs as r order by top`,
+			fmt.Sprintf("/mnt/host/%s", orbName),
+		)
+		if err != nil {
+			log.Error(err)
+			return err
+		}
+		var revision string
+		var top bool
+		for rows.Next() {
+			err = rows.Scan(&revision, &top)
+			if top {
+				fmt.Printf("* %s\n", revision)
+			} else {
+				fmt.Printf("  %s\n", revision)
+			}
+		}
+
+	}
+	return
 }

--- a/cmd/revision_list.go
+++ b/cmd/revision_list.go
@@ -71,8 +71,7 @@ func listRevisions(
 		var rows *sql.Rows
 		rows, err = conn.QueryContext(
 			ctx,
-			`with revs as (select revision, parents, metadata from omni_schema.schema_revisions(omni_vfs.local_fs($1), 'revisions')) 
-                     select revision, not exists (select from revs r1 where r.revision = any(r1.parents)) as top from revs as r order by top`,
+			`select revision from omni_schema.schema_revisions(omni_vfs.local_fs($1), 'revisions')`,
 			fmt.Sprintf("/mnt/host/%s", orbName),
 		)
 		if err != nil {
@@ -80,14 +79,9 @@ func listRevisions(
 			return err
 		}
 		var revision string
-		var top bool
 		for rows.Next() {
-			err = rows.Scan(&revision, &top)
-			if top {
-				fmt.Printf("* %s\n", revision)
-			} else {
-				fmt.Printf("  %s\n", revision)
-			}
+			err = rows.Scan(&revision)
+			fmt.Println(revision)
 		}
 
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -119,7 +119,7 @@ var runCmd = &cobra.Command{
 					},
 				},
 			}
-		err = cluster.Start(ctx, options)
+		err = cluster.Start(ctx, options, nil, nil)
 
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -119,7 +119,7 @@ var runCmd = &cobra.Command{
 					},
 				},
 			}
-		err = cluster.Start(ctx, options, nil, nil)
+		err = cluster.StartWithCurrentUser(ctx, options)
 
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -22,7 +22,7 @@ var startCmd = &cobra.Command{
 		ctx := context.Background()
 
 		readyCh := make(chan orb.OrbCluster, 1)
-		err = cluster.Start(ctx, orb.OrbClusterStartOptions{Runfile: true, Listeners: []orb.OrbStartEventListener{
+		err = cluster.StartWithCurrentUser(ctx, orb.OrbClusterStartOptions{Runfile: true, Listeners: []orb.OrbStartEventListener{
 			{Ready: func(cluster orb.OrbCluster) {
 				readyCh <- cluster
 			}}}})
@@ -36,7 +36,7 @@ var startCmd = &cobra.Command{
 
 		<-readyCh
 
-		fmt.Println("Omnigres Orb cluster started.\n")
+		log.Info("Omnigres Orb cluster started.")
 
 		var endpoints []orb.Endpoint
 		endpoints, err = cluster.Endpoints(ctx)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -69,6 +69,7 @@ func testOrbs(
 	var testTarget, testRunner *sql.DB
 	testRunner, err = cluster.Connect(ctx, "omnigres")
 	if err != nil {
+    log.Error("Could not connect to orb. Ensure the docker container is running, perhaps 'omnigres start' will fix it.")
 		return
 	}
 

--- a/orb/cluster.go
+++ b/orb/cluster.go
@@ -35,7 +35,8 @@ type OrbClusterStartOptions struct {
 
 type OrbCluster interface {
 	Configure(options OrbOptions) error
-	Start(ctx context.Context, options OrbClusterStartOptions) error
+	Start(ctx context.Context, options OrbClusterStartOptions, user *string, entryPoint []string) error
+	StartWithCurrentUser(ctx context.Context, options OrbClusterStartOptions) error
 	Stop(ctx context.Context) error
 	Endpoints(ctx context.Context) ([]Endpoint, error)
 	Connect(ctx context.Context, database ...string) (*sql.DB, error)


### PR DESCRIPTION
For more details see the description of #17 

Problem: Since we removed the previous migrate command we lost the
capability of quickly prototyping applications assembling the code on
our orbs.

Solution: Bring the functionality that calls assemble_schema back to a command called assemble so the functionality is clearly tied to the command name and we can still access it.
This is useful as a primitive for development even if it won't be commonly used once our schema evolution command is in place.