### PR TITLE
Problem: Test singular is counterintuitive. It seems that tests plural is a more common convention.

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -115,7 +115,7 @@ func testOrbs(
 		defer conn.Close()
 
 		// assemble tests in target db
-		orbSource := path.Join(orbName, "test")
+		orbSource := path.Join(orbName, "tests")
 		assembleSchema(ctx, testRunner, orbSource, dbName)
 
 		// run tests


### PR DESCRIPTION
Solution: For now we just change the hardcoded the convetion. It will become a
parameter (with the currently hard-coded value as default).
