### PR TITLE
Problem: The template test database starts httpd workers and hangs the test runner since it waits forever when creating the test runner.

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -46,11 +46,6 @@ var testCmd = &cobra.Command{
 			return fmt.Sprintf("%s_%s_%s", orbName, "test", t)
 		}
 
-		err = assembleOrbs(ctx, cluster, true, orbs, nameForTestDatabase)
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		err = testOrbs(ctx, cluster, orbs, nameForTestDatabase)
 
 		if err != nil {
@@ -69,7 +64,7 @@ func testOrbs(
 	var testTarget, testRunner *sql.DB
 	testRunner, err = cluster.Connect(ctx, "omnigres")
 	if err != nil {
-    log.Error("Could not connect to orb. Ensure the docker container is running, perhaps 'omnigres start' will fix it.")
+		log.Error("Could not connect to orb. Ensure the docker container is running, perhaps 'omnigres start' will fix it.")
 		return
 	}
 
@@ -81,6 +76,10 @@ func testOrbs(
 		}
 		log.Debug("Testing orb", "orbName", orbName, "dbName", dbName)
 
+		_, err = testRunner.ExecContext(ctx, fmt.Sprintf(`create database %q`, dbName))
+		if err != nil {
+			log.Fatal(err)
+		}
 		_, err = testRunner.ExecContext(
 			ctx,
 			"update pg_database set datistemplate = true where datname = $1",
@@ -102,6 +101,9 @@ func testOrbs(
 		}
 		defer removeIsTemplate()
 
+		orbSource := path.Join(orbName, "src")
+		assembleSchema(ctx, testRunner, orbSource, dbName)
+
 		_, err = testTarget.ExecContext(ctx, "create extension omni_test cascade")
 		if err != nil {
 			return err
@@ -115,8 +117,8 @@ func testOrbs(
 		defer conn.Close()
 
 		// assemble tests in target db
-		orbSource := path.Join(orbName, "tests")
-		assembleSchema(ctx, testRunner, orbSource, dbName)
+		orbTestSource := path.Join(orbName, "tests")
+		assembleSchema(ctx, testRunner, orbTestSource, dbName)
 
 		// run tests
 		log.Infof("")


### PR DESCRIPTION
This is due to datistemplate being set after the initial database assemble.

Solution: Create and assemble the test template database inside our
function that tests the orb. Then we can set datistemplate before the
assembleSchema call.
